### PR TITLE
Adição do Carrossel de Banners com uso de Slide

### DIFF
--- a/app.html
+++ b/app.html
@@ -237,15 +237,15 @@
     </header>
     <main>
         <div class="col-md-10 trancaTela">
-            <div id="carouselExampleIndicators" class="carousel slide" data-bs-ride="carousel" style="margin-top: 10%;">
-                <div class="carousel-indicators">
-                    <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="0"
-                        class="active" aria-current="true" aria-label="Slide 1"></button>
-                    <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="1"
+            <div id="carouselExampleCaptions" class="carousel slide" data-bs-ride="carousel" style="margin-top: 10%;">
+                <div class="carousel-indicators" style="margin-bottom: 20%;">
+                    <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="0" class="active"
+                        aria-current="true" aria-label="Slide 1"></button>
+                    <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="1"
                         aria-label="Slide 2"></button>
-                    <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="2"
+                    <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="2"
                         aria-label="Slide 3"></button>
-                    <button type="button" data-bs-target="#carouselExampleIndicators" data-bs-slide-to="3"
+                    <button type="button" data-bs-target="#carouselExampleCaptions" data-bs-slide-to="3"
                         aria-label="Slide 4"></button>
                 </div>
                 <div class="carousel-inner">
@@ -253,7 +253,7 @@
                         <a href="./promo.html#idCardSimples" class="text-decoration-none text-dark">
                             <div class="card mb-3">
                                 <img src="./img/BannerGoodPay.png" class="card-img-top"
-                                    alt="Banner de promoção numero 2">
+                                    alt="Banner de promoção numero 1">
                                 <div class="card-body">
                                     <h5 class="card-title">Vem para o simples: GoodPay</h5>
                                     <p class="card-text">
@@ -261,16 +261,14 @@
                                         organizar
                                         suas finanças com uso de tecnologia Javascript. Ele irá montar e organizar
                                         seus
-                                        gastos usando uma interface Bootstrap fluida e bem desenvolvida para
+                                        gastos para
                                         facilitar
                                         seu
-                                        caixa pessoal. A aplicação tem uso simples e servirá para organiozar em um
-                                        vetor
-                                        de
-                                        obejtos suas entradas e saídas baseadas no uso de cards e alertas para seu
+                                        caixa pessoal. A aplicação tem uso simples e servirá para organizar em um
+                                        suas entradas e saídas baseadas no uso de cards e alertas para seu
                                         entendimento fácil do uso de suas receitas e gastos.
                                     </p>
-                                    <p class="card-text"><small class="text-muted">Abril 20 de 2022</small></p>
+                                    <p class="card-text"><small class="text-muted">Abril 25 de 2022</small></p>
                                 </div>
                             </div>
                         </a>
@@ -292,7 +290,7 @@
                                         vai para o
                                         porquinho de seu caixa.
                                     </p>
-                                    <p class="card-text"><small class="text-muted">Abril 19 de 2022</small></p>
+                                    <p class="card-text"><small class="text-muted">Abril 25 de 2022</small></p>
                                 </div>
                             </div>
                         </a>
@@ -301,7 +299,7 @@
                         <a href="promo.html#idCardPig" class="text-decoration-none text-dark">
                             <div class="card mb-3">
                                 <img src="./img/BannerGoodPay3.png" class="card-img-top"
-                                    alt="Banner de promoção numero 2">
+                                    alt="Banner de promoção numero 3">
                                 <div class="card-body">
                                     <h5 class="card-title">The Pig Time</h5>
                                     <p class="card-text">
@@ -312,7 +310,7 @@
                                         seu
                                         proquinho. Ecomizando e investindo ao mesmo tempo na GoodPay App.
                                     </p>
-                                    <p class="card-text"><small class="text-muted">Abril 19 de 2022</small></p>
+                                    <p class="card-text"><small class="text-muted">Abril 25 de 2022</small></p>
                                 </div>
                             </div>
                         </a>
@@ -323,26 +321,30 @@
                                 <img src="./img/BannerGoodPay4.png" class="card-img-top"
                                     alt="Banner de promoção numero 4">
                                 <div class="card-body">
-                                    <h5 class="card-title">Família é o que importa</h5>
+                                    <h5 class="card-title">Dinheiro para curtir o importante</h5>
                                     <p class="card-text">
-                                        Com os serviços básicos da GoodPay poderá guardar dinheiro desde o nascimento de
-                                        seu filho caso ele passe em uma instituição com nota comprada no Mec Enem maior
-                                        que 800 você tem a chance de triplicar seu porquinho. Assim dar aquele presente
-                                        para quem você planeja sua vida toda. Entre nesta capitalização por R$35 reais e
-                                        ganhe algo incalculável.
+                                        Com o GoodPay você economiza e sempre vai ter dinheiro na sua conta, já que
+                                        temos
+                                        mais de 1645 parceiros que fazem CashBack em diversas compras e ajudamos você
+                                        com
+                                        suas finanças.
+                                        Isso significa: voltar para o saldo positivo em seu caixa para que aproveite
+                                        amigos,
+                                        família e você mesmo! Entre nesta capitalização por R$35 reais e
+                                        ganhe conforto na sua ida financeira.
                                     </p>
-                                    <p class="card-text"><small class="text-muted">Abril 20 de 2022</small></p>
+                                    <p class="card-text"><small class="text-muted">Abril 25 de 2022</small></p>
                                 </div>
                             </div>
                         </a>
                     </div>
                 </div>
-                <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleIndicators"
+                <button class="carousel-control-prev" type="button" data-bs-target="#carouselExampleCaptions"
                     data-bs-slide="prev">
                     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
                     <span class="visually-hidden">Previous</span>
                 </button>
-                <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleIndicators"
+                <button class="carousel-control-next" type="button" data-bs-target="#carouselExampleCaptions"
                     data-bs-slide="next">
                     <span class="carousel-control-next-icon" aria-hidden="true"></span>
                     <span class="visually-hidden">Next</span>


### PR DESCRIPTION
Adição do Carrossel de Banners com uso de Slide.
Deixamos todos os cards com o mesmo width para melhor visualização do usuário, antes o tamanho dos cards era baseado no tamanho dos textos, agora há um padrão.
Créditos: Pâmela.